### PR TITLE
Fix an issue when using imbricated if-else blocks

### DIFF
--- a/src/blogc/renderer.c
+++ b/src/blogc/renderer.c
@@ -361,6 +361,9 @@ blogc_render(bc_slist_t *tmpl, bc_slist_t *sources, bc_trie_t *config, bool list
                         }
                     }
                 }
+                else {
+                    valid_else = false;
+                }
                 free(defined);
                 defined = NULL;
                 if_not = false;


### PR DESCRIPTION
`valid_else` is not correctly set when `evaluate` is true.
Question: did you consider using `bison` to generate a template parser from a grammar?
Is it possible to add an `elseif` template block? It would make our templates cleaner, thanks!